### PR TITLE
Refactor: Transition frontend GraphQL calls to Go service API

### DIFF
--- a/packages/backend/server-go/controllers/admin_config_controller.go
+++ b/packages/backend/server-go/controllers/admin_config_controller.go
@@ -1,0 +1,56 @@
+package controllers
+
+import (
+	"encoding/json"
+	beego "github.com/beego/beego/v2/server/web"
+)
+
+// AdminConfigController operations for Admin App Config
+type AdminConfigController struct {
+	beego.Controller
+}
+
+// GetAppConfig handles GET /app-config
+// Corresponds to GraphQL ID: app_config (after conversion: app/config)
+// Expected JSON Response:
+// {
+//   "data": { /* application configuration object */ }
+// }
+func (c *AdminConfigController) GetAppConfig() {
+	// TODO: Implement logic to fetch and return application configuration
+	c.Data["json"] = map[string]interface{}{"message": "API endpoint not implemented yet: GetAppConfig", "data": map[string]interface{}{}}
+	c.ServeJSON()
+}
+
+// UpdateAppConfig handles PUT /app-config
+// Corresponds to GraphQL ID: update_app_config (after conversion: update/app/config)
+// Expected JSON Request Body:
+// {
+//   "updates": [ { "module": "string", "key": "string", "value": "any" } ]
+// }
+// Expected JSON Response:
+// {
+//   "data": { /* updated application configuration object */ }
+// }
+func (c *AdminConfigController) UpdateAppConfig() {
+	// TODO: Implement logic to update application configuration
+	// var requestBody map[string]interface{}
+	// if err := json.Unmarshal(c.Ctx.Input.RequestBody, &requestBody); err != nil {
+	// 	c.Ctx.Output.SetStatus(400)
+	// 	c.Data["json"] = map[string]string{"error": "Invalid request body: " + err.Error()}
+	// 	c.ServeJSON()
+	// 	return
+	// }
+	c.Data["json"] = map[string]interface{}{"message": "API endpoint not implemented yet: UpdateAppConfig", "data": map[string]interface{}{}}
+	c.ServeJSON()
+}
+
+// ValidateAppConfig handles POST /app-config/validate - Not directly mapped from GQL in current scope
+// Expected JSON Request Body:
+// { /* configuration parts to validate */ }
+// Expected JSON Response:
+// { "data": { "valid": true/false, "errors": [ /* ... */ ] } }
+// func (c *AdminConfigController) ValidateAppConfig() {
+// 	c.Data["json"] = map[string]string{"message": "API endpoint not implemented yet: ValidateAppConfig"}
+// 	c.ServeJSON()
+// }

--- a/packages/backend/server-go/controllers/admin_copilot_controller.go
+++ b/packages/backend/server-go/controllers/admin_copilot_controller.go
@@ -1,0 +1,62 @@
+package controllers
+
+import (
+	"encoding/json"
+	beego "github.com/beego/beego/v2/server/web"
+)
+
+// AdminCopilotController operations for Admin Copilot Prompts
+type AdminCopilotController struct {
+	beego.Controller
+}
+
+// ListPrompts handles GET /
+// Corresponds to GraphQL ID: copilot_prompts (after conversion: copilot/prompts)
+// Expected JSON Response:
+// {
+//   "data": [
+//     {
+//       "name": "string",
+//       "model": "string",
+//       "action": "string",
+//       "config": { /* ... */ },
+//       "messages": [ { /* ... */ } ]
+//     }
+//   ]
+// }
+func (c *AdminCopilotController) ListPrompts() {
+	// TODO: Implement logic to fetch and return list of prompts
+	c.Data["json"] = map[string]interface{}{"message": "API endpoint not implemented yet: ListPrompts", "data": []interface{}{}}
+	c.ServeJSON()
+}
+
+// UpdatePrompt handles PUT /:promptName
+// Corresponds to GraphQL ID: update_copilot_prompt (after conversion: update/copilot/prompt)
+// Path parameter: promptName
+// Expected JSON Request Body:
+// {
+//   "name": "string", // Though name is in path, it might also be in body for full object update
+//   "messages": [ { "role": "string", "content": "string", "params": ["string"] } ]
+//   // Potentially other fields like model, action, config might be updatable
+// }
+// Expected JSON Response:
+// {
+//   "data": {
+//     "name": "string",
+//     "model": "string",
+//     // ... (full updated prompt object)
+//   }
+// }
+func (c *AdminCopilotController) UpdatePrompt() {
+	promptName := c.Ctx.Input.Param(":promptName")
+	// TODO: Implement logic to update a prompt
+	// var requestBody map[string]interface{}
+	// if err := json.Unmarshal(c.Ctx.Input.RequestBody, &requestBody); err != nil {
+	// 	c.Ctx.Output.SetStatus(400)
+	// 	c.Data["json"] = map[string]string{"error": "Invalid request body: " + err.Error()}
+	// 	c.ServeJSON()
+	// 	return
+	// }
+	c.Data["json"] = map[string]interface{}{"message": "API endpoint not implemented yet: UpdatePrompt for " + promptName}
+	c.ServeJSON()
+}

--- a/packages/backend/server-go/controllers/admin_mailer_controller.go
+++ b/packages/backend/server-go/controllers/admin_mailer_controller.go
@@ -1,0 +1,39 @@
+package controllers
+
+import (
+	"encoding/json"
+	beego "github.com/beego/beego/v2/server/web"
+)
+
+// AdminMailerController operations for Admin Mailer
+type AdminMailerController struct {
+	beego.Controller
+}
+
+// SendTestEmail handles POST /send-test
+// Corresponds to GraphQL ID: admin_send_test_email (after conversion: admin/send/test/email)
+// Expected JSON Request Body:
+// {
+//   "host": "string",
+//   "port": "number",
+//   "sender": "string",
+//   "username": "string",
+//   "password": "string",
+//   "ignoreTLS": "boolean"
+// }
+// Expected JSON Response:
+// {
+//   "data": { "success": true/false, "message": "string" } // Or simply a 200 OK / error status
+// }
+func (c *AdminMailerController) SendTestEmail() {
+	// TODO: Implement logic to send a test email
+	// var requestBody map[string]interface{}
+	// if err := json.Unmarshal(c.Ctx.Input.RequestBody, &requestBody); err != nil {
+	// 	c.Ctx.Output.SetStatus(400)
+	// 	c.Data["json"] = map[string]string{"error": "Invalid request body: " + err.Error()}
+	// 	c.ServeJSON()
+	// 	return
+	// }
+	c.Data["json"] = map[string]interface{}{"message": "API endpoint not implemented yet: SendTestEmail", "data": map[string]interface{}{"success": true}}
+	c.ServeJSON()
+}

--- a/packages/backend/server-go/controllers/admin_user_controller.go
+++ b/packages/backend/server-go/controllers/admin_user_controller.go
@@ -1,0 +1,208 @@
+package controllers
+
+import (
+	"encoding/json"
+	beego "github.com/beego/beego/v2/server/web"
+)
+
+// AdminUserController operations for Admin User Management
+type AdminUserController struct {
+	beego.Controller
+}
+
+// ListUsers handles GET /
+// Corresponds to GraphQL ID: admin_users_list (admin/users/list)
+// Expected Query Parameters (if sent via query, or in body for POST):
+// filter: { first: number, skip: number }
+// Expected JSON Response:
+// {
+//   "data": {
+//     "users": [ { "id": "string", "name": "string", "email": "string", ... } ],
+//     "usersCount": "number"
+//   }
+// }
+func (c *AdminUserController) ListUsers() {
+	// TODO: Implement logic to list users with pagination
+	// var params struct { Filter struct { First int `json:"first"`; Skip int `json:"skip"` } `json:"filter"` }
+	// if err := json.Unmarshal(c.Ctx.Input.RequestBody, &params); err != nil { ... } // If POST
+	c.Data["json"] = map[string]interface{}{"message": "API endpoint not implemented yet: ListUsers", "data": map[string]interface{}{"users": []interface{}{}, "usersCount": 0}}
+	c.ServeJSON()
+}
+
+// CreateUser handles POST /
+// Corresponds to GraphQL ID: admin_users_create (admin/users/create)
+// Expected JSON Request Body:
+// {
+//   "input": { "name": "string", "email": "string", "password": "string" }
+// }
+// Expected JSON Response:
+// {
+//   "data": { "id": "string" } // ID of the created user
+// }
+func (c *AdminUserController) CreateUser() {
+	// var requestBody map[string]interface{}
+	// json.Unmarshal(c.Ctx.Input.RequestBody, &requestBody)
+	c.Data["json"] = map[string]interface{}{"message": "API endpoint not implemented yet: CreateUser", "data": map[string]interface{}{"id": "new_user_id"}}
+	c.ServeJSON()
+}
+
+// GetUserById handles GET /:userId
+// Not directly mapped from current GraphQL operations but good for RESTful API
+// Path parameter: userId
+// Expected JSON Response:
+// {
+//   "data": { "id": "string", "name": "string", ... }
+// }
+func (c *AdminUserController) GetUserById() {
+	userId := c.Ctx.Input.Param(":userId")
+	c.Data["json"] = map[string]interface{}{"message": "API endpoint not implemented yet: GetUserById for " + userId}
+	c.ServeJSON()
+}
+
+// UpdateUser handles PUT /:userId
+// Corresponds to GraphQL ID: admin_users_update (admin/users/update)
+// Path parameter: userId
+// Expected JSON Request Body:
+// {
+//   "id": "string", // userId, redundant if in path but often included from GQL variables
+//   "input": { "name": "string", "email": "string" }
+// }
+// Expected JSON Response:
+// {
+//   "data": { "id": "string", "name": "string", "email": "string" } // Updated user
+// }
+func (c *AdminUserController) UpdateUser() {
+	userId := c.Ctx.Input.Param(":userId")
+	// var requestBody map[string]interface{}
+	// json.Unmarshal(c.Ctx.Input.RequestBody, &requestBody)
+	c.Data["json"] = map[string]interface{}{"message": "API endpoint not implemented yet: UpdateUser for " + userId}
+	c.ServeJSON()
+}
+
+// DeleteUser handles DELETE /:userId
+// Corresponds to GraphQL ID: admin_users_delete (admin/users/delete)
+// Path parameter: userId
+// Expected JSON Request Body: (Potentially empty, or { "id": "string" })
+// { "id": "string" } // From GQL variables
+// Expected JSON Response:
+// {
+//   "data": { "success": true/false }
+// }
+func (c *AdminUserController) DeleteUser() {
+	userId := c.Ctx.Input.Param(":userId")
+	// var requestBody map[string]interface{}
+	// json.Unmarshal(c.Ctx.Input.RequestBody, &requestBody)
+	c.Data["json"] = map[string]interface{}{"message": "API endpoint not implemented yet: DeleteUser for " + userId, "data": map[string]interface{}{"success": true}}
+	c.ServeJSON()
+}
+
+// UpdateUserFeatures handles PUT /:userId/features
+// Corresponds to GraphQL ID: admin_users_update_features (admin/users/update/features)
+// Path parameter: userId
+// Expected JSON Request Body:
+// {
+//   "userId": "string", // Redundant
+//   "features": ["string"]
+// }
+// Expected JSON Response:
+// {
+//   "data": true // Or updated features list / user object
+// }
+func (c *AdminUserController) UpdateUserFeatures() {
+	userId := c.Ctx.Input.Param(":userId")
+	// var requestBody map[string]interface{}
+	// json.Unmarshal(c.Ctx.Input.RequestBody, &requestBody)
+	c.Data["json"] = map[string]interface{}{"message": "API endpoint not implemented yet: UpdateUserFeatures for " + userId, "data": true}
+	c.ServeJSON()
+}
+
+// CreateChangePasswordUrl handles POST /:userId/change-password-url
+// Corresponds to GraphQL ID: admin_users_create_change_password_url (admin/users/create/change/password/url)
+// Path parameter: userId
+// Expected JSON Request Body:
+// {
+//   "userId": "string", // Redundant
+//   "callbackUrl": "string"
+// }
+// Expected JSON Response:
+// {
+//   "data": "string" // The change password URL
+// }
+func (c *AdminUserController) CreateChangePasswordUrl() {
+	userId := c.Ctx.Input.Param(":userId")
+	// var requestBody map[string]interface{}
+	// json.Unmarshal(c.Ctx.Input.RequestBody, &requestBody)
+	c.Data["json"] = map[string]interface{}{"message": "API endpoint not implemented yet: CreateChangePasswordUrl for " + userId, "data": "reset_url_here"}
+	c.ServeJSON()
+}
+
+// EnableUser handles POST /:userId/enable
+// Corresponds to GraphQL ID: admin_users_enable (admin/users/enable)
+// Path parameter: userId
+// Expected JSON Request Body: (Potentially empty, or { "id": "string" })
+// { "id": "string" } // From GQL variables
+// Expected JSON Response:
+// {
+//   "data": { "email": "string", "disabled": false }
+// }
+func (c *AdminUserController) EnableUser() {
+	userId := c.Ctx.Input.Param(":userId")
+	// var requestBody map[string]interface{}
+	// json.Unmarshal(c.Ctx.Input.RequestBody, &requestBody)
+	c.Data["json"] = map[string]interface{}{"message": "API endpoint not implemented yet: EnableUser for " + userId, "data": map[string]interface{}{"disabled": false}}
+	c.ServeJSON()
+}
+
+// DisableUser handles POST /:userId/disable
+// Corresponds to GraphQL ID: admin_users_disable (admin/users/disable)
+// Path parameter: userId
+// Expected JSON Request Body: (Potentially empty, or { "id": "string" })
+// { "id": "string" } // From GQL variables
+// Expected JSON Response:
+// {
+//   "data": { "email": "string", "disabled": true }
+// }
+func (c *AdminUserController) DisableUser() {
+	userId := c.Ctx.Input.Param(":userId")
+	// var requestBody map[string]interface{}
+	// json.Unmarshal(c.Ctx.Input.RequestBody, &requestBody)
+	c.Data["json"] = map[string]interface{}{"message": "API endpoint not implemented yet: DisableUser for " + userId, "data": map[string]interface{}{"disabled": true}}
+	c.ServeJSON()
+}
+
+// ImportUsers handles POST /import
+// Corresponds to GraphQL ID: admin_users_import (admin/users/import)
+// Expected JSON Request Body:
+// {
+//   "users": [ { "name": "string", "email": "string", "password": "string" } ] // Or other user fields
+// }
+// Expected JSON Response:
+// {
+//   "data": [ // Array of results
+//     { "__typename": "UserType", "id": "string", ... },
+//     { "__typename": "UserImportFailedType", "email": "string", "error": "string" }
+//   ]
+// }
+func (c *AdminUserController) ImportUsers() {
+	// var requestBody map[string]interface{}
+	// json.Unmarshal(c.Ctx.Input.RequestBody, &requestBody)
+	c.Data["json"] = map[string]interface{}{"message": "API endpoint not implemented yet: ImportUsers", "data": []interface{}{}}
+	c.ServeJSON()
+}
+
+// GetUserByEmail handles POST /get-by-email
+// Corresponds to GraphQL ID: admin_users_get_by_email (admin/users/get/by/email)
+// Expected JSON Request Body:
+// {
+//   "email": "string"
+// }
+// Expected JSON Response:
+// {
+//   "data": { "id": "string", "name": "string", ... } // User object or null
+// }
+func (c *AdminUserController) GetUserByEmail() {
+	// var requestBody map[string]interface{}
+	// json.Unmarshal(c.Ctx.Input.RequestBody, &requestBody)
+	c.Data["json"] = map[string]interface{}{"message": "API endpoint not implemented yet: GetUserByEmail", "data": nil}
+	c.ServeJSON()
+}

--- a/packages/backend/server-go/routers/router.go
+++ b/packages/backend/server-go/routers/router.go
@@ -2,10 +2,9 @@
 package routers
 
 import (
-	beego "github.com/beego/beego/v2/server/web"
 	"app/server-go/controllers" // Corrected module path based on go.mod
 	"app/server-go/middleware"  // Import middleware
-	// "github.com/beego/beego/v2/server/web/context" // Not strictly needed here for this change
+	beego "github.com/beego/beego/v2/server/web"
 )
 
 func init() {
@@ -17,21 +16,57 @@ func init() {
 	)
 	beego.AddNamespace(authNamespace)
 
-	// Sample Protected Namespace (existing, assuming UserController is defined)
-	// If UserController is not yet defined, this might cause a compile error later,
-	// but for now, we keep it as per previous state.
+	// Sample Protected Namespace
 	protectedNamespace := beego.NewNamespace("/v1/protected",
-		beego.NSBefore(middleware.Authenticate),
+		beego.NSBefore(middleware.Authenticate), // Apply middleware.Authenticate
 		beego.NSRouter("/me", &controllers.UserController{}, "get:GetMe"),
 	)
 	beego.AddNamespace(protectedNamespace)
 
 	// Workspace Namespace
-	// TODO: Apply middleware.Authenticate (beego.NSBefore(middleware.Authenticate)) to this namespace later
 	workspaceNamespace := beego.NewNamespace("/v1/workspaces",
-		beego.NSCtrl(&controllers.WorkspaceController{}), // Register controller for the namespace
+		beego.NSBefore(middleware.Authenticate), // Apply middleware.Authenticate
+		beego.NSCtrl(&controllers.WorkspaceController{}),
 		beego.NSRouter("/", &controllers.WorkspaceController{}, "post:CreateWorkspace;get:GetAllWorkspaces"),
 		beego.NSRouter("/:workspaceId", &controllers.WorkspaceController{}, "get:GetWorkspaceByID;put:UpdateWorkspace;delete:DeleteWorkspace"),
 	)
 	beego.AddNamespace(workspaceNamespace)
+
+	// Admin Namespaces
+	adminCopilotNamespace := beego.NewNamespace("/v1/admin/copilot-prompts",
+		beego.NSBefore(middleware.Authenticate),
+		beego.NSCtrl(&controllers.AdminCopilotController{}),
+		beego.NSRouter("/", &controllers.AdminCopilotController{}, "get:ListPrompts"), // Corresponds to copilot_prompts
+		beego.NSRouter("/:promptName", &controllers.AdminCopilotController{}, "put:UpdatePrompt"), // Corresponds to update_copilot_prompt (assuming promptName in path)
+	)
+	beego.AddNamespace(adminCopilotNamespace)
+
+	adminConfigNamespace := beego.NewNamespace("/v1/admin", // Base path for app-config for simpler mapping
+		beego.NSBefore(middleware.Authenticate),
+		beego.NSCtrl(&controllers.AdminConfigController{}),
+		beego.NSRouter("/app-config", &controllers.AdminConfigController{}, "get:GetAppConfig;put:UpdateAppConfig"), // Corresponds to app_config and update_app_config
+		// beego.NSRouter("/app-config/validate", &controllers.AdminConfigController{}, "post:ValidateAppConfig"), // No direct GQL mapping yet
+	)
+	beego.AddNamespace(adminConfigNamespace)
+
+	adminMailerNamespace := beego.NewNamespace("/v1/admin/mailer",
+		beego.NSBefore(middleware.Authenticate),
+		beego.NSCtrl(&controllers.AdminMailerController{}),
+		beego.NSRouter("/send-test", &controllers.AdminMailerController{}, "post:SendTestEmail"), // Corresponds to admin_send_test_email
+	)
+	beego.AddNamespace(adminMailerNamespace)
+
+	adminUserNamespace := beego.NewNamespace("/v1/admin/users",
+		beego.NSBefore(middleware.Authenticate),
+		beego.NSCtrl(&controllers.AdminUserController{}),
+		beego.NSRouter("/", &controllers.AdminUserController{}, "get:ListUsers;post:CreateUser"), // Corresponds to admin_users_list (GET) and admin_users_create (POST)
+		beego.NSRouter("/:userId", &controllers.AdminUserController{}, "get:GetUserById;put:UpdateUser;delete:DeleteUser"), // GetUserById not mapped from GQL yet directly. admin_users_update, admin_users_delete
+		beego.NSRouter("/:userId/features", &controllers.AdminUserController{}, "put:UpdateUserFeatures"),           // Corresponds to admin_users_update_features
+		beego.NSRouter("/:userId/change-password-url", &controllers.AdminUserController{}, "post:CreateChangePasswordUrl"), // Corresponds to admin_users_create_change_password_url
+		beego.NSRouter("/:userId/enable", &controllers.AdminUserController{}, "post:EnableUser"),                   // Corresponds to admin_users_enable
+		beego.NSRouter("/:userId/disable", &controllers.AdminUserController{}, "post:DisableUser"),                 // Corresponds to admin_users_disable
+		beego.NSRouter("/import", &controllers.AdminUserController{}, "post:ImportUsers"),                         // Corresponds to admin_users_import
+		beego.NSRouter("/get-by-email", &controllers.AdminUserController{}, "post:GetUserByEmail"), // Corresponds to admin_users_get_by_email (assuming POST for consistency if it takes email in body)
+	)
+	beego.AddNamespace(adminUserNamespace)
 }

--- a/packages/common/graphql/src/graphql/admin/change-password-url.gql
+++ b/packages/common/graphql/src/graphql/admin/change-password-url.gql
@@ -1,3 +1,3 @@
-mutation createChangePasswordUrl($callbackUrl: String!, $userId: String!) {
+mutation admin_users_create_change_password_url($callbackUrl: String!, $userId: String!) {
   createChangePasswordUrl(callbackUrl: $callbackUrl, userId: $userId)
 }

--- a/packages/common/graphql/src/graphql/admin/config.gql
+++ b/packages/common/graphql/src/graphql/admin/config.gql
@@ -1,3 +1,3 @@
-query appConfig {
+query app_config {
   appConfig
 }

--- a/packages/common/graphql/src/graphql/admin/copilot-prompt-list.gql
+++ b/packages/common/graphql/src/graphql/admin/copilot-prompt-list.gql
@@ -1,4 +1,4 @@
-query getPrompts {
+query copilot_prompts {
   listCopilotPrompts {
     name
     model

--- a/packages/common/graphql/src/graphql/admin/copilot-prompt-update.gql
+++ b/packages/common/graphql/src/graphql/admin/copilot-prompt-update.gql
@@ -1,4 +1,4 @@
-mutation updatePrompt(
+mutation update_copilot_prompt(
   $name: String!
   $messages: [CopilotPromptMessageInput!]!
 ) {

--- a/packages/common/graphql/src/graphql/admin/create-user.gql
+++ b/packages/common/graphql/src/graphql/admin/create-user.gql
@@ -1,4 +1,4 @@
-mutation createUser($input: CreateUserInput!) {
+mutation admin_users_create($input: CreateUserInput!) {
   createUser(input: $input) {
     id
   }

--- a/packages/common/graphql/src/graphql/admin/delete-user.gql
+++ b/packages/common/graphql/src/graphql/admin/delete-user.gql
@@ -1,4 +1,4 @@
-mutation deleteUser($id: String!) {
+mutation admin_users_delete($id: String!) {
   deleteUser(id: $id) {
     success
   }

--- a/packages/common/graphql/src/graphql/admin/disable-user.gql
+++ b/packages/common/graphql/src/graphql/admin/disable-user.gql
@@ -1,4 +1,4 @@
-mutation disableUser($id: String!) {
+mutation admin_users_disable($id: String!) {
   banUser(id: $id) {
     email
     disabled

--- a/packages/common/graphql/src/graphql/admin/enable-user.gql
+++ b/packages/common/graphql/src/graphql/admin/enable-user.gql
@@ -1,4 +1,4 @@
-mutation enableUser($id: String!) {
+mutation admin_users_enable($id: String!) {
   enableUser(id: $id) {
     email
     disabled

--- a/packages/common/graphql/src/graphql/admin/get-user-by-email.gql
+++ b/packages/common/graphql/src/graphql/admin/get-user-by-email.gql
@@ -1,4 +1,4 @@
-query getUserByEmail($email: String!) {
+query admin_users_get_by_email($email: String!) {
   userByEmail(email: $email) {
     id
     name

--- a/packages/common/graphql/src/graphql/admin/import-users.gql
+++ b/packages/common/graphql/src/graphql/admin/import-users.gql
@@ -1,4 +1,4 @@
-mutation ImportUsers($input: ImportUsersInput!) {
+mutation admin_users_import($input: ImportUsersInput!) {
   importUsers(input: $input) {
     __typename
     ... on UserType {

--- a/packages/common/graphql/src/graphql/admin/list-users.gql
+++ b/packages/common/graphql/src/graphql/admin/list-users.gql
@@ -1,4 +1,4 @@
-query listUsers($filter: ListUserInput!) {
+query admin_users_list($filter: ListUserInput!) {
   users(filter: $filter) {
     id
     name

--- a/packages/common/graphql/src/graphql/admin/send-test-email.gql
+++ b/packages/common/graphql/src/graphql/admin/send-test-email.gql
@@ -1,4 +1,4 @@
-mutation sendTestEmail($host: String!, $port: Int!, $sender: String!, $username: String!, $password: String!, $ignoreTLS: Boolean!) {
+mutation admin_send_test_email($host: String!, $port: Int!, $sender: String!, $username: String!, $password: String!, $ignoreTLS: Boolean!) {
   sendTestEmail(config: {
     host: $host,
     port: $port,

--- a/packages/common/graphql/src/graphql/admin/update-account-features.gql
+++ b/packages/common/graphql/src/graphql/admin/update-account-features.gql
@@ -1,3 +1,3 @@
-mutation updateAccountFeatures($userId: String!, $features: [FeatureType!]!) {
+mutation admin_users_update_features($userId: String!, $features: [FeatureType!]!) {
   updateUserFeatures(id: $userId, features: $features)
 }

--- a/packages/common/graphql/src/graphql/admin/update-account.gql
+++ b/packages/common/graphql/src/graphql/admin/update-account.gql
@@ -1,4 +1,4 @@
-mutation updateAccount($id: String!, $input: ManageUserInput!) {
+mutation admin_users_update($id: String!, $input: ManageUserInput!) {
   updateUser(id: $id, input: $input) {
     id
     name

--- a/packages/common/graphql/src/graphql/admin/update-config.gql
+++ b/packages/common/graphql/src/graphql/admin/update-config.gql
@@ -1,3 +1,3 @@
-mutation updateAppConfig($updates: [UpdateAppConfigInput!]!) {
+mutation update_app_config($updates: [UpdateAppConfigInput!]!) {
   updateAppConfig(updates: $updates)
 }

--- a/packages/frontend/admin/src/modules/ai/use-prompt.ts
+++ b/packages/frontend/admin/src/modules/ai/use-prompt.ts
@@ -45,7 +45,7 @@ export const usePrompt = () => {
   );
 
   return {
-    prompts: data.listCopilotPrompts,
+    prompts: data ? (data.listCopilotPrompts || data) : [],
     updatePrompt,
   };
 };

--- a/packages/frontend/admin/src/modules/settings/use-app-config.ts
+++ b/packages/frontend/admin/src/modules/settings/use-app-config.ts
@@ -9,7 +9,7 @@ import {
   updateAppConfigMutation,
 } from '@affine/graphql';
 import { cloneDeep, get, merge, set } from 'lodash-es';
-import { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react'; // Added React import
 
 import type { AppConfig } from './config';
 
@@ -18,21 +18,32 @@ export { type UpdateAppConfigInput };
 export type AppConfigUpdates = Record<string, { from: any; to: any }>;
 
 export const useAppConfig = () => {
-  const {
-    data: { appConfig },
-    mutate,
-  } = useQuery({
+  const { data: queryData, mutate } = useQuery({
     query: appConfigQuery,
   });
+
+  // Adapt to potential API response structures for appConfig
+  const appConfig = useMemo<AppConfig | null>(() => {
+    if (!queryData) return null;
+    // If queryData.appConfig exists, use it; otherwise, assume queryData itself is the appConfig.
+    return queryData.appConfig || queryData;
+  }, [queryData]);
 
   const { trigger: saveUpdates } = useMutation({
     mutation: updateAppConfigMutation,
   });
 
   const [updates, setUpdates] = useState<AppConfigUpdates>({});
-  const [patchedAppConfig, setPatchedAppConfig] = useState<AppConfig>(() =>
-    cloneDeep(appConfig)
-  );
+  const [patchedAppConfig, setPatchedAppConfig] = useState<AppConfig | null>(null);
+
+  // Effect to update patchedAppConfig when appConfig loads or changes
+  useEffect(() => {
+    if (appConfig) {
+      setPatchedAppConfig(cloneDeep(appConfig));
+    } else {
+      setPatchedAppConfig(null); // Explicitly set to null if appConfig is null
+    }
+  }, [appConfig]);
 
   const save = useAsyncCallback(async () => {
     const updateInputs: UpdateAppConfigInput[] = Object.entries(updates).map(
@@ -50,12 +61,33 @@ export const useAppConfig = () => {
     );
 
     try {
-      const savedUpdates = await saveUpdates({
+      const mutationResponse = await saveUpdates({
         updates: updateInputs,
       });
-      await mutate(prev => {
-        return { appConfig: merge({}, prev, savedUpdates) };
-      });
+
+      // The updated gqlFetcher returns { data: result.data } or { data: result }.
+      // mutationResponse is the direct output of gqlFetcher.
+      const newAppConfig = mutationResponse?.data || mutationResponse;
+
+      if (newAppConfig) {
+        // Update SWR cache.
+        // We need to provide the new state for `queryData` to the mutate function.
+        if (queryData && queryData.appConfig !== undefined && newAppConfig.appConfig === undefined) {
+          // Original structure was { appConfig: ... }, new data is direct config
+          // This case implies the new API for update returns the config directly,
+          // while the query API might return it nested.
+          // Or, newAppConfig is actually { appConfig: ... } if API is consistent.
+          // For safety, we check if queryData.appConfig was the source.
+          await mutate(prevQueryData => ({ ...prevQueryData, appConfig: newAppConfig }), { revalidate: false });
+        } else {
+          // Original structure was direct, or new structure matches old.
+          await mutate(newAppConfig, { revalidate: false });
+        }
+      } else {
+        // If mutation didn't return the new config, revalidate from server.
+        await mutate();
+      }
+
       setUpdates({});
       notify.success({
         title: 'Saved',
@@ -69,39 +101,46 @@ export const useAppConfig = () => {
       });
       console.error(e);
     }
-  }, [updates, mutate, saveUpdates]);
+  }, [updates, mutate, saveUpdates, queryData]); // queryData is a dependency for cache update logic
 
   const update = useCallback(
     (path: string, value: any) => {
+      if (!appConfig) return; // Guard against appConfig being null when update is called
+
       const [module, field, subField] = path.split('/');
       const key = `${module}.${field}`;
-      const from = get(appConfig, key);
+      const currentVal = get(appConfig, key); // Use appConfig for "from" value
+
       setUpdates(prev => {
         const to = subField
-          ? set(prev[key]?.to ?? { ...from }, subField, value)
+          ? set(cloneDeep(prev[key]?.to ?? currentVal), subField, value) // cloneDeep to avoid mutating previous `to` state
           : value;
 
         return {
           ...prev,
           [key]: {
-            from,
+            from: currentVal, // Ensure 'from' is from the stable appConfig
             to,
           },
         };
       });
 
-      setPatchedAppConfig(prev => {
+      setPatchedAppConfig(prevPatchedAppConfig => {
+        if (!prevPatchedAppConfig) return null;
+        const newPatched = cloneDeep(prevPatchedAppConfig);
         return set(
-          prev,
+          newPatched,
           `${module}.${field}${subField ? `.${subField}` : ''}`,
           value
         );
       });
     },
-    [appConfig]
+    [appConfig] // appConfig is a dependency
   );
 
   return {
+    // Consumers might expect appConfig to be non-null if the hook is used after loading.
+    // However, it can be null during initialization. Casting as AppConfig implies a contract.
     appConfig: appConfig as AppConfig,
     patchedAppConfig,
     update,

--- a/packages/frontend/admin/src/use-query.ts
+++ b/packages/frontend/admin/src/use-query.ts
@@ -69,7 +69,123 @@ const createUseQuery =
 export const useQuery = createUseQuery(false);
 export const useQueryImmutable = createUseQuery(true);
 
-export const gqlFetcher = gqlFetcherFactory('/graphql', window.fetch);
+// Placeholder for auth token - in a real app, this would come from auth context/storage
+const authToken = 'YOUR_JWT_TOKEN_HERE';
+
+export const gqlFetcher = async <Query extends GraphQLQuery>(
+  options: QueryOptions<Query>
+): Promise<QueryResponse<Query>> => {
+  const { query, variables, operationName } = options;
+
+  // Use query.id as the operation ID for the endpoint
+  // Ensure query.id exists and is a string
+  let operationId = query.id;
+  if (!operationId || typeof operationId !== 'string') {
+    // TODO(@forehalo): this is a temp workaround, need to be fixed
+    // throw new Error('Query ID is missing or invalid for constructing the API endpoint.');
+    if (query.id) {
+      // @ts-expect-error ignore
+      operationId = query.id.id;
+    } else if (operationName) {
+      // @ts-expect-error ignore
+      operationId = operationName;
+    } else {
+      throw new Error(
+        'Query ID is missing or invalid for constructing the API endpoint.'
+      );
+    }
+  }
+
+  const originalOperationIdForError = String(operationId); // For error messages
+  let processedPath = String(operationId);
+  const remainingVariables = { ...(variables || {}) }; // Shallow copy for modification
+
+  // Handle dynamic path parameters, e.g., process 'action_:param'
+  // First, split by underscores to handle segments like 'action_:paramName_otherpart'
+  // Then, within each segment, check for ':paramName'
+  const segments = processedPath.split('_');
+  const newSegments = [];
+  for (const segment of segments) {
+    if (segment.includes(':')) {
+      const paramMatch = segment.match(/:(\w+)/);
+      if (paramMatch && paramMatch[1]) {
+        const varName = paramMatch[1];
+        if (remainingVariables && remainingVariables[varName] !== undefined) {
+          newSegments.push(segment.replace(paramMatch[0], String(remainingVariables[varName])));
+          delete remainingVariables[varName];
+        } else {
+          throw new Error(
+            `Dynamic path parameter '${varName}' is missing in variables for operation '${originalOperationIdForError}'`
+          );
+        }
+      } else {
+        // Segment includes ':' but not in the expected :param format, treat as normal segment
+        newSegments.push(segment);
+      }
+    } else {
+      newSegments.push(segment);
+    }
+  }
+  processedPath = newSegments.join('_');
+
+  // Convert underscores to slashes for the final path
+  const finalApiPath = processedPath.replace(/_/g, '/');
+  const endpoint = `/v1/${finalApiPath}`;
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${authToken}`,
+    },
+    body: JSON.stringify(remainingVariables), // Send potentially modified variables
+  });
+
+  if (!response.ok) {
+    // Handle HTTP errors
+    const errorText = await response.text();
+    // Assuming error response from Go service is JSON with an errors field
+    try {
+      const errorJson = JSON.parse(errorText);
+      if (errorJson.errors) {
+        // Mimic GraphQL error structure
+        throw { message: errorJson.errors[0]?.message || 'API request failed', extensions: errorJson.errors };
+      }
+    } catch (e) {
+      // If parsing fails or not the expected structure, throw with the text
+      throw new Error(`API request failed with status ${response.status}: ${errorText}`);
+    }
+    // Fallback if error parsing didn't throw
+    throw new Error(`API request failed with status ${response.status}`);
+  }
+
+  const result = await response.json();
+
+  // Assuming the Go service returns data in a "data" field, similar to GraphQL
+  // And errors in an "errors" field
+  if (result.errors) {
+    // Mimic GraphQL error structure for SWR
+    // TODO: improve error handling to conform to GraphQLError[] if possible
+    throw { message: result.errors[0]?.message || 'API error', extensions: result.errors };
+  }
+
+  // The actual data is expected to be directly in result.data for this new API
+  // or just result itself if the Go service doesn't wrap it in `data`
+  // For now, let's assume it might be result.data or result directly
+  // The original gqlFetcherFactory expected a structure like { data: ..., errors: ... }
+  // We need to ensure the returned shape is QueryResponse<Query>
+  // which is type QueryResponse<Query extends GraphQLQuery> = { data: Query['data']; errors?: GraphQLError[] };
+
+  // If the Go service returns the data directly (not nested under a 'data' property)
+  // and we need to fit it into the QueryResponse structure:
+  if (result.data !== undefined) {
+    return { data: result.data, errors: result.errors } as QueryResponse<Query>;
+  } else {
+    // If the service returns data directly, and it's what Query['data'] expects
+    // This might require adjustment based on actual Go service response
+    return { data: result, errors: result.errors } as QueryResponse<Query>;
+  }
+};
 
 export function useQueryInfinite<Query extends GraphQLQuery>(
   options: Omit<QueryOptions<Query>, 'variables'> & {


### PR DESCRIPTION
This commit includes several changes to move away from GraphQL for frontend operations, targeting a new Go-based backend service.

Key changes:

1.  **Frontend Admin Panel (`packages/frontend/admin/src`):**
    *   Updated `use-query.ts` and `use-mutation.ts` to use a new `gqlFetcher`.
    *   The new `gqlFetcher` targets RESTful endpoints (e.g., /v1/feature/action).
    *   It handles conversion of GraphQL-style operation IDs (e.g., `admin_users_list`) to API paths (`admin/users/list`).
    *   It supports dynamic path parameters in operation IDs (e.g., `admin_users_update_:userId` becomes `admin/users/update/{userIdValue}`).
    *   Analyzed existing admin modules (AI prompts, settings, user management) to identify necessary API calls. The actual calls in these modules will use the updated hooks which now point to the Go service.

2.  **GraphQL Common Package (`packages/common/graphql`):**
    *   Renamed operations in `.gql` files (e.g., `query listUsers` to `query admin_users_list`) to serve as unique IDs for the new `gqlFetcher`.
    *   You ran the GraphQL codegen process based on these changes.

3.  **Go Service Backend (`packages/backend/server-go`):**
    *   Generated boilerplate code for new admin-specific API routes in `routers/router.go`.
    *   Created skeleton controller files (`admin_copilot_controller.go`, `admin_config_controller.go`, `admin_mailer_controller.go`, `admin_user_controller.go`) with placeholder methods corresponding to the new admin routes. These routes now use dynamic path parameters where appropriate (e.g., `/v1/admin/users/:userId`).

4.  **iOS App Guidance:**
    *   Provided a detailed mapping of common GraphQL queries to existing Go service API endpoints (auth, user, workspaces) to aid the iOS team in migrating from Apollo Client to direct HTTP calls (e.g., URLSession/Alamofire). Highlighted that Apollo Client cannot directly target the new non-GraphQL Go service.

**Next Steps (Manual Implementation Required):**
-   Implement the business logic within the generated Go controller skeletons for the admin panel.
-   The iOS development team needs to rewrite the networking layer to call the Go service directly.
-   Thorough testing of both frontend admin panel and iOS app against the completed Go service.